### PR TITLE
Disable ssl verify for conda buids

### DIFF
--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -5,8 +5,10 @@
 ####################################
 set -ex
 
+export HOME=${WORKSPACE}
 export PATH="/opt/conda/bin:$PATH"
 source activate base
+conda config --set ssl_verify false
 conda install -k conda-build conda-verify anaconda-client
 conda build conda/recipe
 anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-gpuci} --label main --skip-existing /opt/conda/conda-bld/linux-64/gpuci-tools*.tar.bz2


### PR DESCRIPTION
Our Jenkins jobs started experiencing some connection issues ([src](https://gpuci.gpuopenanalytics.com/job/gpuci/job/conda/job/gpuci-tools/22/console)) when trying to run  the `gpuci_conda_retry` [test command](https://github.com/rapidsai/gpuci-tools/blob/main/conda/recipe/meta.yaml#L20). Upon further inspection, it seems like these connection errors stemmed from some SSL issues. Disabling SSL seems to have resolved this issue.

I'm not sure why this issue occurs. But I noticed we do something similar in the `docker` repo ([link](https://github.com/rapidsai/docker/blob/branch-0.15/context/.condarc#L1)). I'm wondering if it has anything to do with our conda mirror.