### PR TITLE
ENH Update logger with colors and better styling

### DIFF
--- a/tools/gpuci_conda_retry
+++ b/tools/gpuci_conda_retry
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# condaretry - wrapper for conda that retries the command after a CondaHTTPError
+# gpuci_conda_retry - wrapper for conda that retries the command after a CondaHTTPError
 # or ChecksumMismatchError (ideally, any conda error that is normally resolved
 # by retrying).
 
 set -o pipefail
 
 condaretry_help="
-condaretry options:
+gpuci_conda_retry options:
 
    --condaretry_max_retries=n      Retry the conda command at most n times (default is 3)
    --condaretry_sleep_interval=n   Sleep n seconds between retries (default is 5)

--- a/tools/gpuci_conda_retry
+++ b/tools/gpuci_conda_retry
@@ -53,9 +53,9 @@ while (( ${exitcode} != 0 )) && \
        (grep -q ChecksumMismatchError: ${outfile})); do
 
    retries=$(expr ${retries} + 1)
-   gpuci_logger "gpuci_conda_retry: ${retries} OF ${max_retries} - sleeping for ${sleep_interval} seconds..."
+   gpuci_logger "gpuci_conda_retry: ${retries} OF ${max_retries} -> sleeping for ${sleep_interval} seconds..."
    sleep ${sleep_interval}
-   gpuci_logger "gpuci_conda_retry: sleep done"
+   gpuci_logger "gpuci_conda_retry: sleep done..."
 
    ${condaCmd} ${args} 2>&1| tee ${outfile}
    exitcode=$?

--- a/tools/gpuci_conda_retry
+++ b/tools/gpuci_conda_retry
@@ -53,12 +53,9 @@ while (( ${exitcode} != 0 )) && \
        (grep -q ChecksumMismatchError: ${outfile})); do
 
    retries=$(expr ${retries} + 1)
-   echo "========================================"
-   echo "CONDA RETRY ${retries} OF ${max_retries}"...
-   echo -n "sleeping for ${sleep_interval} seconds..."
+   gpuci_logger "gpuci_conda_retry: ${retries} OF ${max_retries} - sleeping for ${sleep_interval} seconds..."
    sleep ${sleep_interval}
-   echo "done"
-   echo "========================================"
+   gpuci_logger "gpuci_conda_retry: sleep done"
 
    ${condaCmd} ${args} 2>&1| tee ${outfile}
    exitcode=$?

--- a/tools/gpuci_logger
+++ b/tools/gpuci_logger
@@ -6,9 +6,17 @@
 #
 function gpuci_logger {
   TS=`date '+%x %T'`
-  echo -e "\n"
-  echo ">>gpuCI log<< [$TS] $@"
-  echo -e "\n"
+  MSG_CNT=`echo "$@" | wc -c`
+  WIDTH=$((MSG_CNT+6))
+  BAR=""
+  for ((i = 0 ; i <= $WIDTH ; i++)); do
+    BAR="${BAR}─"
+  done
+
+  echo -e "\n\e[32mgpuCI logger\e[0m » [$TS]"
+  echo -e "\e[32m┌${BAR}┐\e[0m"
+  echo -e "\e[32m|    $@    |\e[0m"
+  echo -e "\e[32m└${BAR}┘\e[0m\n"
 }
 
 gpuci_logger $@

--- a/tools/gpuci_retry
+++ b/tools/gpuci_retry
@@ -39,12 +39,9 @@ function gpuci_retry {
     while (( ${retcode} != 0 )) && \
           (( ${retries} < ${max_retries} )); do
       ((retries++))
-      echo "========================================"
-      echo "GPUCI_RETRY> ${retries} of ${max_retries}..."
-      echo -n "GPUCI_RETRY> sleeping for ${sleep_interval} seconds..."
+      gpuci_logger "gpuci_retry: ${retries} of ${max_retries} -> sleeping for ${sleep_interval} seconds..."
       sleep ${sleep_interval}
-      echo "done"
-      echo "========================================"
+      gpuci_logger "gpuci_retry: sleep done..."
 
       ${command} ${args}
       retcode=$?


### PR DESCRIPTION
Make the gpuCI logger standout in logs using colors and a new format. Also updated retry scripts to use `gpuci_logger` for their status messages.

New style:
![Screen Shot 2020-07-21 at 19 54 45](https://user-images.githubusercontent.com/1915404/88118654-1cf68780-cb8c-11ea-94e8-8f360de53f8a.png)

Old style:
![Screen Shot 2020-07-21 at 19 54 58](https://user-images.githubusercontent.com/1915404/88118649-1b2cc400-cb8c-11ea-8ec3-a4a7892b7d19.png)
