### PR TITLE
ENH Retry on JSONDecodeError

### DIFF
--- a/tools/gpuci_conda_retry
+++ b/tools/gpuci_conda_retry
@@ -58,6 +58,9 @@ function runConda {
         elif grep -q ChecksumMismatchError: ${outfile}; then
             retryingMsg="Retrying, found 'ChecksumMismatchError:' in output..."
             needToRetry=1
+        elif grep -q JSONDecodeError: ${outfile}; then
+            retryingMsg="Retrying, found 'JSONDecodeError:' in output..."
+            needToRetry=1
         else
             echo_stderr "Exiting, no retryable conda errors detected: 'ChecksumMismatchError:' or 'CondaHTTPError:'"
         fi


### PR DESCRIPTION
`JSONDecodeError`s have become more common and typically are resolved with a retry. Adding this error code to reduce the number of failed jobs due to this error.

Example job with [failure](https://gpuci.gpuopenanalytics.com/job/gpuci/job/gpuci-build-environment/job/rapidsai-test-build/32/BUILD_IMAGE=gpuci%2Frapidsai,CUDA_VER=11.0,DOCKER_FILE=base-runtime.Dockerfile,FROM_IMAGE=gpuci%2Fminiconda-cuda,IMAGE_NAME=rapidsai,IMAGE_TYPE=runtime,LINUX_VER=centos7,PYTHON_VER=3.8,RAPIDS_CHANNEL=rapidsai-nightly,RAPIDS_VER=0.16/console)