### PR TITLE
FIX Remove output for successful runs

### DIFF
--- a/tools/gpuci_conda_retry
+++ b/tools/gpuci_conda_retry
@@ -62,8 +62,11 @@ function runConda {
             retryingMsg="Retrying, found 'JSONDecodeError:' in output..."
             needToRetry=1
         else
-            echo_stderr "Exiting, no retryable conda errors detected: 'ChecksumMismatchError:' or 'CondaHTTPError:'"
+            echo_stderr "Exiting, no retryable conda errors detected: 'ChecksumMismatchError:' or 'CondaHTTPError:' or 'JSONDecodeError:'"
         fi
+    else
+        # Successful run
+        break
     fi
 
     if (( ${needToRetry} == 1 )) && \


### PR DESCRIPTION
Prevent retry script from showing empty error message on successful runs. Also update retry message to include `JSONDecodeError`

This is the empty error message that will be removed:
![Screen Shot 2020-09-30 at 16 28 23](https://user-images.githubusercontent.com/1915404/94736313-04e47680-033a-11eb-8bfa-6a69dac99928.png)
