### PR TITLE
FIX Remove output for successful runs

### DIFF
--- a/tools/gpuci_conda_retry
+++ b/tools/gpuci_conda_retry
@@ -66,7 +66,7 @@ function runConda {
         fi
     else
         # Successful run
-        break
+        exit
     fi
 
     if (( ${needToRetry} == 1 )) && \

--- a/tools/gpuci_conda_retry
+++ b/tools/gpuci_conda_retry
@@ -66,7 +66,7 @@ function runConda {
         fi
     else
         # Successful run
-        exit
+        exit 0
     fi
 
     if (( ${needToRetry} == 1 )) && \


### PR DESCRIPTION
This is a continuation of #9. With the new `break` statement, the following warning is displayed on successful `conda` operations:

![image](https://user-images.githubusercontent.com/7400326/94956628-83682200-04ba-11eb-9567-b62ce2c444ce.png)

I believe the `break` should be switched to an `exit 0`.