### PR TITLE
ENH Add error code to `gpuci_retry` and fix `gpuci_logger` color output

### DIFF
--- a/tools/gpuci_logger
+++ b/tools/gpuci_logger
@@ -13,10 +13,10 @@ function gpuci_logger {
     BAR="${BAR}─"
   done
 
-  echo -e "\n\e[32mgpuCI logger\e[0m » [$TS]"
-  echo -e "\e[32m┌${BAR}┐\e[0m"
-  echo -e "\e[32m|    $@    |\e[0m"
-  echo -e "\e[32m└${BAR}┘\e[0m\n"
+  echo -e "\n\033[32mgpuCI logger\033[0m » [$TS]"
+  echo -e "\033[32m┌${BAR}┐\033[0m"
+  echo -e "\033[32m|    $@    |\033[0m"
+  echo -e "\033[32m└${BAR}┘\033[0m\n"
 }
 
 gpuci_logger $@

--- a/tools/gpuci_retry
+++ b/tools/gpuci_retry
@@ -39,9 +39,9 @@ function gpuci_retry {
     while (( ${retcode} != 0 )) && \
           (( ${retries} < ${max_retries} )); do
       ((retries++))
-      gpuci_logger "gpuci_retry: ${retries} of ${max_retries} -> sleeping for ${sleep_interval} seconds..."
+      gpuci_logger "gpuci_retry: retry ${retries} of ${max_retries} | exit code: (${retcode}) -> sleeping for ${sleep_interval} seconds..."
       sleep ${sleep_interval}
-      gpuci_logger "gpuci_retry: sleep done..."
+      gpuci_logger "gpuci_retry: sleep done -> retrying..."
 
       ${command} ${args}
       retcode=$?


### PR DESCRIPTION
Two small improvements

- Add error code to `gpuci_retry` output message
- Fix `gpuci_logger` color output