### PR TITLE
FIX Use CONDA_EXE to use the active conda version

### DIFF
--- a/tools/gpuci_conda_retry
+++ b/tools/gpuci_conda_retry
@@ -26,7 +26,7 @@ args=""
 # Temporarily set this to something else (eg. a script called "testConda" that
 # prints "CondaHTTPError:" and exits with 1) for testing this script.
 #condaCmd=./testConda
-condaCmd=conda
+condaCmd=${CONDA_EXE:=conda}
 
 # Function to output messages to stderr
 # FIXME - extend `gpuci_logger` or make another script for this


### PR DESCRIPTION
This prevents cases where `conda` is installed in the active environment when the base `conda` should be used for operations

Have tested this locally and it works, correctly resolving issues we saw in rapidsai/gpuci-build-environment#137 without the need for a duplicate `.condarc`