### PR TITLE
Add ChunkedEncodingError handling to gpuci_conda_retry

### DIFF
--- a/tools/gpuci_conda_retry
+++ b/tools/gpuci_conda_retry
@@ -86,8 +86,11 @@ function runConda {
         elif grep -q JSONDecodeError: ${outfile}; then
             retryingMsg="Retrying, found 'JSONDecodeError:' in output..."
             needToRetry=1
+        elif grep -q ChunkedEncodingError: ${outfile}; then
+            retryingMsg="Retrying, found 'ChunkedEncodingError:' in output..."
+            needToRetry=1
         else
-            echo_stderr "Exiting, no retryable conda errors detected: 'ChecksumMismatchError:' or 'CondaHTTPError:' or 'JSONDecodeError:'"
+            echo_stderr "Exiting, no retryable conda errors detected: 'ChecksumMismatchError:' or 'CondaHTTPError:' or 'JSONDecodeError:' or 'ChunkedEncodingError:'"
         fi
 
         if (( ${needToRetry} == 1 )) && \


### PR DESCRIPTION
Encountered a new error that should be retry-able.

Job: https://gpuci.gpuopenanalytics.com/view/RAPIDS%20-%20GPU%20Matrix/job/rapidsai/job/gpuci/job/cudf/job/branches/job/cudf-gpu-matrix-branch-0.18/CUDA=11.0,LINUX_VERSION=ubuntu18.04,PYTHON_VERSION=3.7/74/console