### PR TITLE
Update `gpuci_retry` to Better Accept Arguments with Spaces

### DIFF
--- a/tools/gpuci_retry
+++ b/tools/gpuci_retry
@@ -29,12 +29,11 @@
 function gpuci_retry {
     command=$1
     shift
-    args=$*
     max_retries=${GPUCI_RETRY_MAX:=3}
     retries=0
     sleep_interval=${GPUCI_RETRY_SLEEP:=10}
 
-    ${command} ${args}
+    ${command} "$@"
     retcode=$?
     while (( ${retcode} != 0 )) && \
           (( ${retries} < ${max_retries} )); do
@@ -43,10 +42,10 @@ function gpuci_retry {
       sleep ${sleep_interval}
       gpuci_logger "gpuci_retry: sleep done -> retrying..."
 
-      ${command} ${args}
+      ${command} "$@"
       retcode=$?
     done
     return ${retcode}
 }
 
-gpuci_retry $@
+gpuci_retry "$@"


### PR DESCRIPTION
While working on cuml PR: https://github.com/rapidsai/cuml/pull/3581, an issue was discovered when trying to use `gpuci_retry` on a command with spaces in the argument. For example, when trying to use the following:
```sh
gpuci_retry ./codecov.sh -U "--connect-timeout 60" -Z
```
The arguments would get concatenated into a string and reparsed due to using `args=$*`. This has the effect of passing the arguments to the command like:
```sh
./codecov.sh "-U" "--connect-timeout" "60" "-Z"
```
Which can break some parsers. In my testing, no amount of single or double quotes can fix this issue without changing the script. [This](https://stackoverflow.com/a/3816747/634820) SO answer sums the situation up well.

This PR just updates how arguments are forwarded along in the retry command to prevent issues with how the args are parsed.