### PR TITLE
Don't set `MAMBA_BIN`

### DIFF
--- a/tools/gpuci_mamba_retry
+++ b/tools/gpuci_mamba_retry
@@ -51,7 +51,6 @@ args=""
 # Temporarily set this to something else (eg. a script called "testConda" that
 # prints "CondaHTTPError:" and exits with 1) for testing this script.
 #mambaCmd=./testConda
-MAMBA_BIN=$CONDA_PREFIX/bin/mamba
 mambaCmd=${MAMBA_BIN:=mamba}
 
 # Function to output messages to stderr


### PR DESCRIPTION
Don't want to set `MAMBA_BIN` explicitly otherwise we can't override it.