### PR TITLE
Clear tarball cache before retrying on CondaMultiError.

### DIFF
--- a/tools/gpuci_conda_retry
+++ b/tools/gpuci_conda_retry
@@ -71,6 +71,7 @@ function runConda {
     ${condaCmd} ${args} 2>&1| tee ${outfile}
     exitcode=$?
     needToRetry=0
+    needToClean=0
     retryingMsg=""
 
     if (( ${exitcode} != 0 )); then
@@ -90,8 +91,9 @@ function runConda {
             retryingMsg="Retrying, found 'ChunkedEncodingError:' in output..."
             needToRetry=1
         elif grep -q CondaMultiError: ${outfile}; then
-            retryingMsg="Retrying, found 'CondaMultiError:' in output..."
+            retryingMsg="Retrying after cleaning tarball cache, found 'CondaMultiError:' in output..."
             needToRetry=1
+            needToClean=1
         elif grep -q EOFError: ${outfile}; then
             retryingMsg="Retrying, found 'EOFError:' in output..."
             needToRetry=1
@@ -106,6 +108,10 @@ function runConda {
         else
             # Give reason for retry
             echo_stderr $retryingMsg
+            if (( ${needToClean} == 1 )); then
+                echo_stderr "Cleaning tarball cache before retrying..."
+                ${condaCmd} clean --tarballs -y
+            fi
         fi
 fi
 }


### PR DESCRIPTION
 In #19, a feature was added to retry gpuCI when the conda error `CondaMultiError` occurs. I saw some tests fail on gpuCI ([log file here](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cudf/job/prb/job/cudf-cpu-python-build/CUDA=11.4,PYTHON=3.7/4775/console)) because of a download error for `cudatoolkit`. The download was incomplete, so the first attempt threw a `CondaMultiError` (didn't match the expected `Content-Length`). However, when it was retried, conda used the invalid (previously downloaded) package from its cache, so the second attempt also failed.

This PR [cleans the tarball cache](https://docs.conda.io/projects/conda/en/latest/commands/clean.html) when `CondaMultiError` occurs, to re-download any corrupted packages before retrying.

Another example of this failure can be found here: https://github.com/rapidsai/cugraph/pull/1937?#issuecomment-966747825