### PR TITLE
Add gpuci_mamba_retry to shell installation script.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,7 @@ mkdir -p "$HOME/.gpuci"
 install_tool gpuci_retry
 install_tool gpuci_logger
 install_tool gpuci_conda_retry
+install_tool gpuci_mamba_retry
 
 logging "Adding ~/.gpuci to PATH in ~/.bashrc ..."
 touch "$HOME/.bashrc"


### PR DESCRIPTION
`gpuci_mamba_retry` was not installed by the `install.sh` script. This PR fixes that.