### PR TITLE
gpuci_mamba_retry: check "Multi-download failed"

### DIFF
--- a/tools/gpuci_mamba_retry
+++ b/tools/gpuci_mamba_retry
@@ -89,8 +89,11 @@ function runMamba {
         elif grep -q EOFError: ${outfile}; then
             retryingMsg="Retrying, found 'EOFError:' in output..."
             needToRetry=1
+        elif grep -q "Multi-download failed" ${outfile}; then
+            retryingMsg="Retrying, found 'Multi-download failed' in output..."
+            needToRetry=1
         else
-            echo_stderr "Exiting, no retryable mamba errors detected: 'ChecksumMismatchError:' or 'CondaHTTPError:' or 'JSONDecodeError:' or 'EOFError:'"
+            echo_stderr "Exiting, no retryable mamba errors detected: 'ChecksumMismatchError:' or 'CondaHTTPError:' or 'JSONDecodeError:' or 'EOFError:' or 'Multi-download failed'"
         fi
 
         if (( ${needToRetry} == 1 )) && \


### PR DESCRIPTION
Recently I have encounter download errors in CI where `gpuci_mamba_retry` didn't retry. One example is [here](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/kvikio/job/prb/job/kvikio-cpu-cuda-build/CUDA=11.5/113/console).

This PR makes `gpuci_mamba_retry` retry if `Multi-download failed` is found in the Mamba output, which happens when Mamba fails to download multiple targets: https://github.com/mamba-org/mamba/blob/93a3f8edaeb0851d242edd8cc250626d07433db2/libmamba/src/core/fetch.cpp#L797