### PR TITLE
Add reusable scripts for CI

### DIFF
--- a/tools/rapids-build-type
+++ b/tools/rapids-build-type
@@ -1,0 +1,39 @@
+#!/bin/bash
+# A utility script that examines environment variables provided
+# by Jenkins to determine whether a given build is a "nightly", "pull-request",
+# or "branch" build.
+set -e
+
+echo_build_type() {
+  echo -n "$1"
+  exit 0
+}
+
+# Nightly build:
+# For nightly builds, $IS_NIGHTLY is set to "true".
+# For other build, IS_NIGHTLY is unset.
+if [[ "${IS_NIGHTLY}" = "true" ]]; then
+  echo_build_type "nightly"
+fi
+
+# PR build from organization members:
+# For these builds, GIT_BRANCH is equal to "PR-<NUM>"
+# i.e. PR-784
+if [[ "${GIT_BRANCH}" =~ ^PR-[0-9]+$ ]]; then
+  echo_build_type "pull-request"
+fi
+
+# PR build from external contributors (non-organization members):
+# For these builds, GIT_BRANCH is equal to "external-pr-<NUM>"
+# i.e. external-pr-784
+# Technically these builds are branch builds since we copy the
+# forked code to the source repository.
+if [[ "${GIT_BRANCH}" =~ ^external-pr-[0-9]+$ ]]; then
+  echo_build_type "pull-request"
+fi
+
+# Branch builds:
+# For these builds, GIT_BRANCH is equal to the branch name,
+# which can be anything
+# i.e. feature-branch-23, branch-22.04, etc.
+echo_build_type "branch"

--- a/tools/rapids-download-conda-from-s3
+++ b/tools/rapids-download-conda-from-s3
@@ -22,6 +22,7 @@ TAR_FILE="/tmp/${PKG_TYPE}.tar.gz"
 
 # Download tarball
 S3_PATH=$(rapids-s3-path "${PKG_TYPE}")
+echo "Downloading from ${S3_PATH}" 1>&2 # echo to stderr
 aws s3 cp --only-show-errors "${S3_PATH}" "${TAR_FILE}"
 
 # Extract tarball

--- a/tools/rapids-download-conda-from-s3
+++ b/tools/rapids-download-conda-from-s3
@@ -1,0 +1,33 @@
+#!/bin/bash
+# A utility script that downloads a conda artifact archive from S3, untars it,
+# and prints the location where it was untarred.
+# Positional Arguments:
+#   1) a string of "cpp" or "python" which determines which conda artifact
+#      should be downloaded
+set -e
+
+PKG_TYPE="$1"
+case "${PKG_TYPE}" in
+  cpp)
+    ;&
+  python)
+    ;;
+  *)
+    echo 'Pass "cpp" or "python" as an argument.'
+    exit 1
+    ;;
+esac
+
+TAR_FILE="/tmp/${PKG_TYPE}.tar.gz"
+
+# Download tarball
+S3_PATH=$(rapids-s3-path "${PKG_TYPE}")
+aws s3 cp --only-show-errors "${S3_PATH}" "${TAR_FILE}"
+
+# Extract tarball
+CHANNEL="/tmp/${PKG_TYPE}_channel"
+mkdir -p "${CHANNEL}"
+tar -xzf "${TAR_FILE}" -C "${CHANNEL}"
+
+# echo path to untarred contents
+echo -n "${CHANNEL}"

--- a/tools/rapids-s3-path
+++ b/tools/rapids-s3-path
@@ -1,0 +1,72 @@
+#!/bin/bash
+# A utility script that examines environment variables provided
+# by Jenkins to print out an S3 path where the expected artifact
+# should be.
+# Positional Arguments:
+#   1) a string of "cpp" or "python" which determines which artifact path
+#      name should be returned
+set -e
+
+PKG_TYPE="$1"
+case "${PKG_TYPE}" in
+  cpp)
+    ;&
+  python)
+    ;;
+  *)
+    echo 'Pass "cpp" or "python" as an argument.'
+    exit 1
+    ;;
+esac
+
+BUILD_TYPE=$(rapids-build-type)
+case "${BUILD_TYPE}" in
+  pull-request)
+    # For PRs, $GIT_BRANCH is either like:
+    # PR-989 or external-pr-989
+    S3_DIRECTORY_ID="${GIT_BRANCH##*-}"
+    S3_PREFIX="ci"
+    ;;
+  branch)
+    S3_DIRECTORY_ID="${GIT_BRANCH}"
+    S3_PREFIX="ci"
+    ;;
+  nightly)
+    S3_DIRECTORY_ID="$(date +%F)"
+    S3_PREFIX="nightly"
+    ;;
+  *)
+    echo 'Missing valid "BUILD_TYPE" environment variable.'
+    exit 1
+    ;;
+esac
+
+# Parse path values from Jenkins environment variables
+REPO_NAME=$(basename ${GIT_URL} .git)
+SHORT_HASH=${GIT_COMMIT:0:7}
+PKG_NAME="${REPO_NAME}_${PKG_TYPE}"
+if [[ "${PKG_TYPE}" == "python" ]]; then
+  PKG_NAME+="_${PY_VER/./}"
+fi
+PKG_NAME+="_$(arch).tar.gz"
+
+#
+# The output format should be one of the following:
+#
+## For PR builds:
+## s3://rapids-downloads/ci/<REPO_NAME>/pull-request/<PR_NUMBER>/<SHORT_HASH>/<PKG_NAME>
+
+## For branch builds:
+## s3://rapids-downloads/ci/<REPO_NAME>/branch/<BRANCH_NAME>/<SHORT_HASH>/<PKG_NAME>
+
+## For nightly builds:
+## s3://rapids-downloads/nightly/<REPO_NAME>/<DATE>/<SHORT_HASH>/<PKG_NAME>
+
+
+S3_PATH="s3://rapids-downloads/${S3_PREFIX}/${REPO_NAME}/"
+if [[ "${BUILD_TYPE}" != "nightly" ]]; then
+  S3_PATH+="${BUILD_TYPE}/"
+fi
+S3_PATH+="${S3_DIRECTORY_ID}/${SHORT_HASH}/${PKG_NAME}"
+
+echo -n "${S3_PATH}"

--- a/tools/rapids-upload-conda-to-s3
+++ b/tools/rapids-upload-conda-to-s3
@@ -23,4 +23,5 @@ tar -czf "${TAR_FILE}" -C /tmp/conda-bld-output .
 
 # Upload tarball
 S3_PATH=$(rapids-s3-path "${PKG_TYPE}")
+echo "Uploading to ${S3_PATH}" 1>&2 # echo to stderr
 aws s3 cp --only-show-errors "${TAR_FILE}" "${S3_PATH}"

--- a/tools/rapids-upload-conda-to-s3
+++ b/tools/rapids-upload-conda-to-s3
@@ -1,0 +1,26 @@
+#!/bin/bash
+# A utility script that tars up `/tmp/conda-bld-output` and uploads it to S3
+# Positional Arguments:
+#   1) a string of "cpp" or "python" which determines which conda artifact
+#      should be uploaded
+set -e
+
+PKG_TYPE="$1"
+case "${PKG_TYPE}" in
+  cpp)
+    ;&
+  python)
+    ;;
+  *)
+    echo 'Pass "cpp" or "python" as an argument.'
+    exit 1
+    ;;
+esac
+
+# Create tarball
+TAR_FILE="/tmp/${PKG_TYPE}.tar.gz"
+tar -czf "${TAR_FILE}" -C /tmp/conda-bld-output .
+
+# Upload tarball
+S3_PATH=$(rapids-s3-path "${PKG_TYPE}")
+aws s3 cp --only-show-errors "${TAR_FILE}" "${S3_PATH}"

--- a/tools/rapids-upload-to-anaconda
+++ b/tools/rapids-upload-to-anaconda
@@ -47,7 +47,7 @@ anaconda \
   -t "${CONDA_TOKEN}" \
   upload \
   -u "${CONDA_USERNAME}" \
-  --label main \
+  --label "${CONDA_UPLOAD_LABEL:-main}" \
   --skip-existing \
   --no-progress \
   ${PKGS_TO_UPLOAD}

--- a/tools/rapids-upload-to-anaconda
+++ b/tools/rapids-upload-to-anaconda
@@ -1,0 +1,53 @@
+#!/bin/bash
+# A utility script that find all of the conda packages within a folder and
+# uploads them to Anaconda.org
+# Positional Arguments:
+#   1) a directory path to search for conda packages
+set -e
+
+SEARCH_DIR="$1"
+
+if [ -z "${SEARCH_DIR}" ]; then
+  echo "Please provide a search directory."
+  exit 1
+fi
+
+if [ ! -d "${SEARCH_DIR}" ]; then
+  echo "Directory ${SEARCH_DIR} does not exist."
+  exit 1
+fi
+
+PKGS_TO_UPLOAD=$(find "${SEARCH_DIR}" -name "*.tar.bz2")
+if [ -z "${PKGS_TO_UPLOAD}" ]; then
+  echo "Couldn't find any packages to upload in: ${SEARCH_DIR}."
+  ls -l "${SEARCH_DIR}/"*
+  exit 1
+fi
+
+case "${BUILD_TYPE}" in
+  branch)
+    ;&
+  nightly)
+    ;;
+  *)
+    echo 'Only branch builds and nightly builds are uploaded to Anaconda.org'
+    exit 1
+    ;;
+esac
+
+CONDA_USERNAME="rapidsai-nightly"
+CONDA_TOKEN="${NIGHTLY_CONDA_TOKEN}"
+if [[ "${GIT_BRANCH}" == "main" ]]; then
+  CONDA_USERNAME="rapidsai"
+  CONDA_TOKEN="${STABLE_CONDA_TOKEN}"
+fi
+
+
+anaconda \
+  -t "${CONDA_TOKEN}" \
+  upload \
+  -u "${CONDA_USERNAME}" \
+  --label main \
+  --skip-existing \
+  --no-progress \
+  ${PKGS_TO_UPLOAD}

--- a/tools/rapids-upload-to-anaconda
+++ b/tools/rapids-upload-to-anaconda
@@ -42,7 +42,7 @@ if [[ "${GIT_BRANCH}" == "main" ]]; then
   CONDA_TOKEN="${STABLE_CONDA_TOKEN}"
 fi
 
-
+echo "Uploading packages to Anaconda.org: ${PKGS_TO_UPLOAD}" 1>&2 # echo to stderr
 anaconda \
   -t "${CONDA_TOKEN}" \
   upload \


### PR DESCRIPTION
This PR adds some reusable scripts that can be used in our Jenkinsfile pipeline steps. The following scripts are added:

- `rapids-build-type`
- `rapids-s3-path`
- `rapids-upload-conda-to-s3`
- `rapids-downloads-from-s3`
- `rapids-upload-to-anaconda`


They are intended to be used like this:

```sh
# CPP Build Stage
conda build \
  conda/recipes/librmm

rapids-upload-conda-to-s3 cpp


# Python Build Stage
CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)

conda build \
  -c "${CPP_CHANNEL}"
  conda/recipes/rmm

rapids-upload-conda-to-s3 python


# GPU Test Stage
CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)

conda install \
  -c "${CPP_CHANNEL}"
  -c "${PYTHON_CHANNEL}"
  rmm librmm librmm-tests

# ... run tests


# Upload To Anaconda Stage

CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)

rapids-upload-to-anaconda "${CPP_CHANNEL}"
rapids-upload-to-anaconda "${PYTHON_CHANNEL}"
```