### PR TITLE
Update tools to match new `pull-request` pattern

### DIFF
--- a/tools/rapids-build-type
+++ b/tools/rapids-build-type
@@ -16,19 +16,12 @@ if [[ "${IS_NIGHTLY}" = "true" ]]; then
   echo_build_type "nightly"
 fi
 
-# PR build from organization members:
-# For these builds, GIT_BRANCH is equal to "PR-<NUM>"
-# i.e. PR-784
-if [[ "${GIT_BRANCH}" =~ ^PR-[0-9]+$ ]]; then
-  echo_build_type "pull-request"
-fi
-
-# PR build from external contributors (non-organization members):
-# For these builds, GIT_BRANCH is equal to "external-pr-<NUM>"
-# i.e. external-pr-784
+# PR builds:
+# For these builds, GIT_BRANCH is equal to "pull-request/<NUM>"
+# i.e. pull-request/784
 # Technically these builds are branch builds since we copy the
 # forked code to the source repository.
-if [[ "${GIT_BRANCH}" =~ ^external-pr-[0-9]+$ ]]; then
+if [[ "${GIT_BRANCH}" =~ ^pull-request/[0-9]+$ ]]; then
   echo_build_type "pull-request"
 fi
 

--- a/tools/rapids-s3-path
+++ b/tools/rapids-s3-path
@@ -22,9 +22,9 @@ esac
 BUILD_TYPE=$(rapids-build-type)
 case "${BUILD_TYPE}" in
   pull-request)
-    # For PRs, $GIT_BRANCH is either like:
-    # PR-989 or external-pr-989
-    S3_DIRECTORY_ID="${GIT_BRANCH##*-}"
+    # PR commits are merge commits (i.e. refs/pull/<PR_NUM>/merge),
+    # so get the parent commit ID to match the last PR SHA.
+    S3_DIRECTORY_ID="$(git rev-list HEAD^2 -1)"
     S3_PREFIX="ci"
     ;;
   branch)


### PR DESCRIPTION
This PR updates our helper tools to match how pull requests will be identified. Since all pull requests will now be copied from `refs/pull/<PR_NUM>/merge` to `pull-request/<PR_NUM>` branches in the source repository, I made the following changes:

1. Removed old patterns from `rapids-build-type`
2. Update `rapids-s3-path` to use the parent commit SHA for the hash on https://downloads.rapids.ai