### PR TITLE
Update prefixes for pull-requests

### DIFF
--- a/tools/rapids-build-type
+++ b/tools/rapids-build-type
@@ -16,19 +16,12 @@ if [[ "${IS_NIGHTLY}" = "true" ]]; then
   echo_build_type "nightly"
 fi
 
-# PR build from organization members:
-# For these builds, GIT_BRANCH is equal to "PR-<NUM>"
-# i.e. PR-784
-if [[ "${GIT_BRANCH}" =~ ^PR-[0-9]+$ ]]; then
-  echo_build_type "pull-request"
-fi
-
-# PR build from external contributors (non-organization members):
-# For these builds, GIT_BRANCH is equal to "external-pr-<NUM>"
-# i.e. external-pr-784
+# PR builds:
+# For these builds, GIT_BRANCH is equal to "pull-request/<NUM>"
+# i.e. pull-request/784
 # Technically these builds are branch builds since we copy the
 # forked code to the source repository.
-if [[ "${GIT_BRANCH}" =~ ^external-pr-[0-9]+$ ]]; then
+if [[ "${GIT_BRANCH}" =~ ^pull-request/[0-9]+$ ]]; then
   echo_build_type "pull-request"
 fi
 

--- a/tools/rapids-s3-path
+++ b/tools/rapids-s3-path
@@ -22,9 +22,9 @@ esac
 BUILD_TYPE=$(rapids-build-type)
 case "${BUILD_TYPE}" in
   pull-request)
-    # For PRs, $GIT_BRANCH is either like:
-    # PR-989 or external-pr-989
-    S3_DIRECTORY_ID="${GIT_BRANCH##*-}"
+    # For PRs, $GIT_BRANCH is like:
+    # pull-request/989
+    S3_DIRECTORY_ID="${GIT_BRANCH##*/}"
     S3_PREFIX="ci"
     ;;
   branch)

--- a/tools/rapids-size-checker
+++ b/tools/rapids-size-checker
@@ -1,26 +1,21 @@
 #!/bin/bash
 set -e
 
-# CHANGE_TARGET is provided by PR builds.
-# It's not set for branch builds (i.e. external PRs)
-BASE_BRANCH=${CHANGE_TARGET:-""}
 REPO_NAME=$(basename "${GIT_URL}" .git)
 ORG_NAME=$(basename "$(dirname "${GIT_URL}")")
 
-if [ -z "$BASE_BRANCH" ]; then
-  echo "Retrieving base branch from GitHub API:"
-  # For PRs, $GIT_BRANCH is either like:
-  # PR-989 or external-pr-989
-  PR_NUM="${GIT_BRANCH##*-}"
-  [[ -n "$GH_TOKEN" ]] && CURL_HEADERS=('-H' "Authorization: token ${GH_TOKEN}")
-  RESP=$(
-    curl \
-      -H "Accept: application/vnd.github.v3+json" \
-      "${CURL_HEADERS[@]}" \
-      "https://api.github.com/repos/${ORG_NAME}/${REPO_NAME}/pulls/${PR_NUM}"
-  )
-  BASE_BRANCH=$(echo "${RESP}" | jq -r '.base.ref')
-fi
+echo "Retrieving base branch from GitHub API:"
+# For PRs, $GIT_BRANCH is like:
+# pull-request/989
+PR_NUM="${GIT_BRANCH##*/}"
+[[ -n "$GH_TOKEN" ]] && CURL_HEADERS=('-H' "Authorization: token ${GH_TOKEN}")
+RESP=$(
+curl \
+    -H "Accept: application/vnd.github.v3+json" \
+    "${CURL_HEADERS[@]}" \
+    "https://api.github.com/repos/${ORG_NAME}/${REPO_NAME}/pulls/${PR_NUM}"
+)
+BASE_BRANCH=$(echo "${RESP}" | jq -r '.base.ref')
 
 DIFF_FILES=$(mktemp)
 LARGE_FILES=$(mktemp)
@@ -37,6 +32,7 @@ conda activate rapids
 git fetch origin
 git diff --name-only origin/"${BASE_BRANCH}"..HEAD > "${DIFF_FILES}"
 
+echo "### Comparing ${BASE_BRANCH} to HEAD:"
 echo '### Files modified in current PR'
 while read -r FILE; do
     echo "Size check ${FILE}"


### PR DESCRIPTION
Since our new CI testing process involves copying _all_ PRs to the source repository (instead of just PRs from external contributors), this PR updates the scripts in this repository to reflect those changes.