### PR TITLE
Add `boa` installation to `rapids-env-update`

### DIFF
--- a/tools/rapids-env-update
+++ b/tools/rapids-env-update
@@ -16,3 +16,6 @@ if [[ "${BUILD_TYPE}" != "pull-request" && "${GIT_BRANCH}" = branch-* ]] ; then
   VERSION_SUFFIX=$(date +%y%m%d)
   export VERSION_SUFFIX
 fi
+
+# FIXME: Remove this line once `boa` is properly installed in our CI images
+gpuci_mamba_retry install -y -c conda-forge boa


### PR DESCRIPTION
This PR adds a `boa` installation step to `rapids-env-update` since it is needed in all repositories. This step should be removed once `boa` is properly installed in our CI images.