### PR TITLE
feat: Search for & upload `.conda` packages

### DIFF
--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -22,4 +22,6 @@ fi
 conda config --set ssl_verify false
 conda install -k conda-build conda-verify anaconda-client
 conda build conda/recipe
-anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-gpuci} --label main --skip-existing /opt/conda/conda-bld/${ARCH_DIR}/gpuci-tools*.tar.bz2
+anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-gpuci} --label main --skip-existing \
+  /opt/conda/conda-bld/${ARCH_DIR}/gpuci-tools*.tar.bz2 \
+;

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -22,7 +22,6 @@ fi
 conda config --set ssl_verify false
 conda install -k conda-build conda-verify anaconda-client
 conda build conda/recipe
-anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-gpuci} --label main --skip-existing \
-  /opt/conda/conda-bld/${ARCH_DIR}/gpuci-tools*.conda \
-  /opt/conda/conda-bld/${ARCH_DIR}/gpuci-tools*.tar.bz2 \
-;
+
+pkgs_to_upload=$(find "/opt/conda/conda-bld/${ARCH_DIR}" -name "gpuci-tools*.conda" -o -name "gpuci-tools*.tar.bz2")
+anaconda -t "${MY_UPLOAD_KEY}" upload -u "${CONDA_USERNAME:-gpuci}" --label main --skip-existing "${pkgs_to_upload}"

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -23,5 +23,6 @@ conda config --set ssl_verify false
 conda install -k conda-build conda-verify anaconda-client
 conda build conda/recipe
 anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-gpuci} --label main --skip-existing \
+  /opt/conda/conda-bld/${ARCH_DIR}/gpuci-tools*.conda \
   /opt/conda/conda-bld/${ARCH_DIR}/gpuci-tools*.tar.bz2 \
 ;

--- a/tools/rapids-upload-to-anaconda
+++ b/tools/rapids-upload-to-anaconda
@@ -17,7 +17,7 @@ if [ ! -d "${SEARCH_DIR}" ]; then
   exit 1
 fi
 
-PKGS_TO_UPLOAD=$(find "${SEARCH_DIR}" -name "*.tar.bz2")
+PKGS_TO_UPLOAD=$(find "${SEARCH_DIR}" -name "*.conda" -o -name "*.tar.bz2")
 if [ -z "${PKGS_TO_UPLOAD}" ]; then
   echo "Couldn't find any packages to upload in: ${SEARCH_DIR}."
   ls -l "${SEARCH_DIR}/"*


### PR DESCRIPTION
Part of issue: https://github.com/rapidsai/build-planning/issues/98

* Uses [`find`]( https://www.man7.org/linux/man-pages/man1/find.1p.html )'s `-o` option to search for `.conda` or `.tar.bz2` files to upload
* Tack on `.conda` glob to `anaconda upload` command